### PR TITLE
minimatch@^3.0.2, fix RegExp DoS vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "homepage": "https://github.com/joshwnj/minimatch-all",
   "dependencies": {
-    "minimatch": "^1.0.0"
+    "minimatch": "^3.0.2"
   },
   "devDependencies": {
     "tape": "^3.0.0"


### PR DESCRIPTION
Installing `minimatch-all` currently outputs a scary `minimatch` deprecation warning:

```
npm WARN deprecated minimatch@1.0.0: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
```

Luckily v2 focused on adding browserify support, and then v3 focused on removing it. So moving from v1 -> v3 is actually pretty straightforward and should only require a patch version update from `minimatch-all`. Changelog here: https://github.com/isaacs/minimatch/commits/master
